### PR TITLE
Password hashing using bcrypt

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -1,68 +1,77 @@
 var Strategy = require('passport-local').Strategy;
 var users = require('../routes/users');
+var bcrypt   = require('bcrypt');
+
+const saltRounds = 10
 
 module.exports = function(passport) {
 
-	passport.use('local', new Strategy({
-			usernameField : 'username',
-	      passwordField : 'password',
-	      passReqToCallback : true // allows us to pass back the entire request to the callback
-		},
-		function(req, username, password, cb) {
-		    users.findByUsername(username, function(err, user) {
-		      if(err) { 
-		      	return cb(err); 
-		      }
-		      if(!user){ 
-		      	return cb(null, false); 
-		      }
-		      if(user.password != password) { 
-		     		return cb(null, false, req.flash('loginMessage', 'Oops... Wrong password. Please try again.')); 
-		     	}
-		      return cb(null, user);
-		    });
-		  }
-	));
-	
-	passport.use('local-signup', new Strategy({
-			usernameField : 'username',
-	      passwordField : 'password',
-	      passReqToCallback : true // allows us to pass back the entire request to the callback
-	  },
-	  function(req, username, password, cb) {
-	  	
-		  	users.verifyUser(username, function(err, user) {
-		      if(err){ 
-		      	return cb(err, req.flash('loginMessage', 'A system error has occurred. ')); 
-		      }
-		      
-		      if(user){ 
-		      	return cb(null, false, req.flash('loginMessage', 'This user name is already taken. Please try a new one.')); 
-		      }
-		      else{
-		      	var isValidPass = users.verifyPassword(password);
-		      	
-		      	if(isValidPass){
-		      		users.createUser(username, password, cb, req);
-		      	}
-		      	else {
-		      		return cb(null, false, req.flash('loginMessage', 'Your password is too weak. Please try a new one.'));
-		      	}
-		      }
-		    });
-		}
-	));
-	  
-	  
-	passport.serializeUser(function(user, cb) {
-	  cb(null, user.id);
-	});
-	
-	passport.deserializeUser(function(id, cb) {
-	  users.findById(id, function (err, user) {
-	    if (err) { return cb(err); }
-	    cb(null, user);
-	  });
-	});
+    passport.use('local', new Strategy({
+            usernameField : 'username',
+          passwordField : 'password',
+          passReqToCallback : true // allows us to pass back the entire request to the callback
+        },
+        function(req, username, password, cb) {
+
+            users.findByUsername(username, function(err, user) {
+                if(err) { 
+                    return cb(err); 
+                }
+                if(!user){ 
+                    return cb(null, false); 
+                }
+                // Load hash from your password DB.
+                bcrypt.compare(password, user.password, function(err, res) {
+                    // Success
+                    if (res == true)
+                        return cb(null, user); 
+                    else {
+                    	return cb(null, false, req.flash('loginMessage', 'Oops... Wrong password. Please try again.')); 
+                    }
+                });
+            });
+          }
+    ));
+    
+    passport.use('local-signup', new Strategy({
+            usernameField : 'username',
+          passwordField : 'password',
+          passReqToCallback : true // allows us to pass back the entire request to the callback
+      },
+      function(req, username, password, cb) {
+        
+            users.verifyUser(username, function(err, user) {
+              if(err){ 
+                return cb(err, req.flash('loginMessage', 'A system error has occurred. ')); 
+              }
+              
+              if(user){ 
+                return cb(null, false, req.flash('loginMessage', 'This user name is already taken. Please try a new one.')); 
+              }
+              else{
+                var isValidPass = users.verifyPassword(password);
+                
+                if(isValidPass){
+                    users.createUser(username, password, cb, req);
+                }
+                else {
+                    return cb(null, false, req.flash('loginMessage', 'Your password is too weak. Please try a new one.'));
+                }
+              }
+            });
+        }
+    ));
+      
+      
+    passport.serializeUser(function(user, cb) {
+      cb(null, user.id);
+    });
+    
+    passport.deserializeUser(function(id, cb) {
+      users.findById(id, function (err, user) {
+        if (err) { return cb(err); }
+        cb(null, user);
+      });
+    });
 
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "./node_modules/.bin/jasmine-node tests/spec"
   },
   "dependencies": {
-    "bcrypt" : "latest",
+    "bcrypt-pbkdf": "^1.0.1",
     "body-parser": "~1.13.2",
     "connect-flash": "^0.1.1",
     "cookie-parser": "~1.3.5",
@@ -24,11 +24,11 @@
     "jsdom": "^7.2.2",
     "morgan": "~1.6.1",
     "passport": "^0.2.2",
+    "passport-facebook": "~1.0.2",
+    "passport-google-oauth": "~0.1.5",
     "passport-http": "^0.3.0",
     "passport-local": "^1.0.0",
-    "passport-facebook" : "~1.0.2", 
-    "passport-twitter" : "~1.0.2",  
-    "passport-google-oauth" : "~0.1.5",
+    "passport-twitter": "~1.0.2",
     "pg": "^4.4.3",
     "python-shell": "^0.3.0",
     "request": "^2.67.0",

--- a/routes/users.js
+++ b/routes/users.js
@@ -3,148 +3,141 @@ var router = express.Router();
 var pg = require('pg');
 var bcrypt   = require('bcrypt');
 
-var config = require('../config.js');
-
 const saltRounds = 10
 
+var config = require('../config.js');
+
 if(process.env.OPENSHIFT_POSTGRESQL_DB_URL){
-	var dbUrl = process.env.OPENSHIFT_POSTGRESQL_DB_URL + "/climbmapper";
+    var dbUrl = process.env.OPENSHIFT_POSTGRESQL_DB_URL + "/climbmapper";
 }
 var conString = dbUrl || 'postgres://'+config.user_name+':'+config.password+'@localhost:5432/climbmapper';
 
 
+
 exports.createUser = function(username, password, cb, req) {
 
-	// Hash the password
-	bcrypt.hash(password, saltRounds, function(err, hash) {
+    // Hash the password
+    bcrypt.hash(password, saltRounds, function(err, hash) {
    
-	  	// Store hash in password DB. 
-	   	pg.connect(conString, function(err, client, done) {
-		   console.log("creating user")
-		   var query = client.query("INSERT INTO appuser(username, password, displayname, email) VALUES ('"+username+"','"+hash+"','"+username+"',null);");
-		   
-		//   var userQuery = client.query("SELECT id, username, password, displayname, email FROM appuser WHERE username = '"+username+"';");
-		   
-			done();  
-		   
-			
-			var newUserObj = {
-		 			"id": 0, // TODO: this is fine for now  
-		 			"username": username, 
-		 			"displayname": username, 
-		 			"emails": ["email"] 
-		 	};
-		 	
-		 	return cb(null, newUserObj, req.flash('loginMessage', 'Now login with your new user. I know I should log you in automatically at this point but for now I need you to do it.'));
-		})
-	 
-	});
-	//pg.end();
+        // Store hash in your password DB. 
+        pg.connect(conString, function(err, client, done) {
+           console.log("creating user")
+           var query = client.query("INSERT INTO appuser(username, password, displayname, email) VALUES ('"+username+"','"+hash+"','"+username+"',null);");
+           
+           done();  
+        })
+    });
+            
+    var newUserObj = {
+            "id": 0, // TODO: this is fine for now  
+            "username": username, 
+            "displayname": username, 
+            "emails": ["email"] 
+    };
+    
+    return cb(null, newUserObj, req.flash('loginMessage', 'Now login with your new user. I know I should log you in automatically at this point but for now I need you to do it.'));
+ 
+    
+    //pg.end();
 }
 
 exports.updateProfile = function(res, user, mpuserkey, email, password, getnotifications) {
    
-	// Hash the password
-	bcrypt.hash(password, saltRounds, function(err, hash) {
-	   pg.connect(conString, function(err, client, done) {
+   pg.connect(conString, function(err, client, done) {
 
-		   if(mpuserkey.length > 0) {
-		   	client.query("UPDATE appuser SET mountainprojkey='"+mpuserkey+ "' WHERE id ='"+user.id.toString()+"';");
-		   }
-		   if(email.length > 0){
-		   	client.query("UPDATE appuser SET email='"+email+"' WHERE id ='"+user.id.toString()+"';");
-		   }
-		   if(password.length > 0){
-		   	client.query("UPDATE appuser SET password='"+password+"' WHERE id ='"+user.id.toString()+"';");
-		   }
-		   if(getnotifications !== user.getnotifications){
-		   	client.query("UPDATE appuser SET getnotifications='"+getnotifications+"' WHERE id ='"+user.id.toString()+"';");
-		   }
-		   
-		   done()
+       if(mpuserkey.length > 0) {
+        client.query("UPDATE appuser SET mountainprojkey='"+mpuserkey+ "' WHERE id ='"+user.id.toString()+"';");
+       }
+       if(email.length > 0){
+        client.query("UPDATE appuser SET email='"+email+"' WHERE id ='"+user.id.toString()+"';");
+       }
+       if(password.length > 0){
+        client.query("UPDATE appuser SET password='"+password+"' WHERE id ='"+user.id.toString()+"';");
+       }
+       if(getnotifications !== user.getnotifications){
+        client.query("UPDATE appuser SET getnotifications='"+getnotifications+"' WHERE id ='"+user.id.toString()+"';");
+       }
+       
+       done()
 
-		   res.redirect('/profile');
-		})
+       res.redirect('/profile');
+    })
    
-	});
    //pg.end();
 }
 
 
 exports.verifyPassword = function (password) {
-	// TODO - make this work
-	// Load hash from your password DB. 
-	bcrypt.compare(password, hash, function(err, res) {
-	    res == true 
-	});
-	bcrypt.compare(password, hash, function(err, res) {
-	    res == false 
-	});
+    if(password.length < 1){
+        return false;
+    }
+    
+    return true;
 }
 
 
 exports.verifyUser = function (username, cb) {
    
    pg.connect(conString, function(err, client, done) {
-		var query = client.query("SELECT id, username, password, displayname, email, mountainprojkey, getnotifications FROM appuser;");
-	   
-	    query.on('row', function(row, result) {
-	    	if (row) {
-	    	  rowJSON = { "id": row.id, "username": row.username, "password": row.password, "displayname": row.displayname, "emails": [row.email], "mountainprojkey": row.mountainprojkey, "getnotifications": row.getnotifications };
-	        result.addRow(rowJSON);
-	      }
-	    })
-	    
-	    query.on("end", function (result) {
-	    		var records = result.rows;
-				var theUser = null;
-				
-	    		for (var i = 0; i < records.length; i++) {
-			      var record = records[i];
-			      if (record.username === username) {
-			        return cb(null, record);
-			      }
-			   }
-			    
-			   return cb(null, false);
-	    })
-	    
-	    done();
-	 })
-	 
-	 //pg.end();
+        var query = client.query("SELECT id, username, password, displayname, email, mountainprojkey, getnotifications FROM appuser;");
+       
+        query.on('row', function(row, result) {
+            if (row) {
+              rowJSON = { "id": row.id, "username": row.username, "password": row.password, "displayname": row.displayname, "emails": [row.email], "mountainprojkey": row.mountainprojkey, "getnotifications": row.getnotifications };
+            result.addRow(rowJSON);
+          }
+        })
+        
+        query.on("end", function (result) {
+                var records = result.rows;
+                var theUser = null;
+                
+                for (var i = 0; i < records.length; i++) {
+                  var record = records[i];
+                  if (record.username === username) {
+                    return cb(null, record);
+                  }
+               }
+                
+               return cb(null, false);
+        })
+        
+        done();
+     })
+     
+     //pg.end();
 }
 
 
 exports.findByUsername = function(username, cb) {
-  process.nextTick(function() { 	  
+  process.nextTick(function() {       
     pg.connect(conString, function(err, client, done) {
-	    var query = client.query("SELECT id, username, password, displayname, email, mountainprojkey, getnotifications FROM appuser;");
-	   
-	    query.on('row', function(row, result) {
-	    	  
-	        if (row) {
-	        		rowJSON = { "id": row.id, "username": row.username, "password": row.password, "displayname": row.displayname, "emails": [row.email], "mountainprojkey": row.mountainprojkey, "getnotifications": row.getnotifications };
-	        		result.addRow(rowJSON);
-	        }
-	    })
-	    
-	    query.on("end", function (result) {
-	    		
-	    		var records = result.rows;
-	    
-	    		for (var i = 0; i < records.length; i++) {
-			      var record = records[i];
-			      if (record.username === username) {
-			        return cb(null, record);
-			      }
-			    }
-	
-	    		return cb(null, null);
-	    })
-	    
-	    done();
-	 })
+        var query = client.query("SELECT id, username, password, displayname, email, mountainprojkey, getnotifications FROM appuser;");
+       
+        query.on('row', function(row, result) {
+              
+            if (row) {
+                    rowJSON = { "id": row.id, "username": row.username, "password": row.password, "displayname": row.displayname, "emails": [row.email], "mountainprojkey": row.mountainprojkey, "getnotifications": row.getnotifications };
+                    result.addRow(rowJSON);
+            }
+        })
+        
+        query.on("end", function (result) {
+                
+                var records = result.rows;
+        
+                for (var i = 0; i < records.length; i++) {
+                  var record = records[i];
+                  if (record.username === username) {
+                    return cb(null, record);
+                  }
+                }
+    
+                return cb(null, null);
+        })
+        
+        done();
+     })
   });
   
   //pg.end();
@@ -152,36 +145,36 @@ exports.findByUsername = function(username, cb) {
 
 
 /*exports.findByEmail = function(email, cb) {
-  process.nextTick(function() { 	  
-  	 var client = new pg.Client(conString);
+  process.nextTick(function() {       
+     var client = new pg.Client(conString);
     client.connect();
     
     var query = client.query("SELECT id, username, password, displayname, email FROM appuser;");
    
     query.on('row', function(row, result) {
-    	  
+          
         if (row) {
-        		rowJSON = { "id": row.id, "username": row.username, "password": row.password, "displayname": row.displayname, "emails": [row.email] };
-        		result.addRow(rowJSON);
+                rowJSON = { "id": row.id, "username": row.username, "password": row.password, "displayname": row.displayname, "emails": [row.email] };
+                result.addRow(rowJSON);
         }
     })
     
     query.on("end", function (result) {
-    		
-    		var records = result.rows;
-    		
-    		for (var i = 0, len = records.length; i < len; i++) {
-		      var record = records[i];
-		      console.log(record.emails[0], " - ", email)
-		      if (record.emails[0] === email) {
-		        return cb(null, record);
-		      }
-		      else{
-					console.log("nope")		      
-		      }
-		    }
+            
+            var records = result.rows;
+            
+            for (var i = 0, len = records.length; i < len; i++) {
+              var record = records[i];
+              console.log(record.emails[0], " - ", email)
+              if (record.emails[0] === email) {
+                return cb(null, record);
+              }
+              else{
+                    console.log("nope")           
+              }
+            }
 
-    		return cb(null, null);
+            return cb(null, null);
     })
 
   });
@@ -191,29 +184,29 @@ exports.findByUsername = function(username, cb) {
 exports.findById = function(id, cb) {
   process.nextTick(function() {  
     pg.connect(conString, function(err, client, done) {
-	    var query = client.query("SELECT id, username, password, displayname, email, mountainprojkey, getnotifications FROM appuser;");
-	   
-	    query.on('row', function(row, result) {
-	        if (row) {
-	        		rowJSON = { "id": row.id, "username": row.username, "password": row.password, "displayname": row.displayname, "emails": [row.email], "mountainprojkey": row.mountainprojkey, "getnotifications": row.getnotifications };
-	        		result.addRow(rowJSON);
-	        }
-	    })
-	    
-	    query.on("end", function (result) { 		
-	    		var records = result.rows; 		
-	    		for (var i = 0, len = records.length; i < len; i++) {
-			      var record = records[i];
-			      if (record.id === id) {
-			        return cb(null, record);
-			      }
-			    }
-	
-	    		return cb(null, null);
-	    })
-	    
-	    done();
-	 })
+        var query = client.query("SELECT id, username, password, displayname, email, mountainprojkey, getnotifications FROM appuser;");
+       
+        query.on('row', function(row, result) {
+            if (row) {
+                    rowJSON = { "id": row.id, "username": row.username, "password": row.password, "displayname": row.displayname, "emails": [row.email], "mountainprojkey": row.mountainprojkey, "getnotifications": row.getnotifications };
+                    result.addRow(rowJSON);
+            }
+        })
+        
+        query.on("end", function (result) {         
+                var records = result.rows;      
+                for (var i = 0, len = records.length; i < len; i++) {
+                  var record = records[i];
+                  if (record.id === id) {
+                    return cb(null, record);
+                  }
+                }
+    
+                return cb(null, null);
+        })
+        
+        done();
+     })
   });
   
   //pg.end();


### PR DESCRIPTION
This update uses the bcrypt node module to hash plain-text passwords on signup. To verify the passwords it takes the plain-text and hashes it, then compares this hash with the hash in the DB.